### PR TITLE
Get tests running again

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,6 @@
-require 'rubygems'
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 require 'logger'
 require 'sequel'
-
-module Minitest
-  @@installed_at_exit = true
-end if defined?(M)
 
 gem 'minitest'
 require 'minitest/autorun'
@@ -12,7 +8,7 @@ require 'minitest/hooks/default'
 require 'minitest/shared_description'
 
 Sequel::Model.cache_associations = false if ENV['SEQUEL_NO_CACHE_ASSOCIATIONS']
-Sequel.cache_anonymous_models = false
+Sequel::Model.cache_anonymous_models = false
 
 unless defined?(DB)
   DB = Sequel.connect(ENV['IMPALA_URL'] || 'jdbc:hive2://localhost:21050/;auth=noSasl')


### PR DESCRIPTION
The first commit fixes spec_helper.rb to get the tests running again.

As before, you can run all tests in a file directly by executing them:

```
IMPALA_URL='...' ruby spec/database_spec.rb
```

You can run individual tests as well (this comes from minitest):

```
IMPALA_URL='...' ruby spec/database_spec.rb -n '/should store underlying wrapped exception in Sequel::DatabaseError/
```

You can all tests using rake:

```
IMPALA_URL='...' rake
```

I'll continue to add commits to fix any currently broken tests and then to add tests for new features added after the test suite was committed where the commits didn't include tests.