### PR TITLE
Support TESTS_DIV_MOD environment variable when testing

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,6 +18,20 @@ IDENTIFIER_MANGLING = !!ENV['IDENTIFIER_MANGLING'] unless defined?(IDENTIFIER_MA
 DB.extension(:identifier_mangling) if IDENTIFIER_MANGLING
 
 class Minitest::HooksSpec
+  if ENV['TESTS_DIV_MOD']
+    div, mod = ENV['TESTS_DIV_MOD'].split(' ', 2).map(&:to_i)
+    raise "invalid TESTS_DIV_MOD div: #{div}" unless div >= 2
+    raise "invalid TESTS_DIV_MOD mod: #{mod} (div: #{div})" unless mod >= 0 && mod < div
+    test_number = -1
+    inc = proc{test_number+=1}
+    
+    define_singleton_method(:it) do |*a, &block|
+      if inc.call % div == mod
+        super(*a, &block)
+      end
+    end
+  end
+
   def log
     begin
       DB.loggers << Logger.new(STDOUT)


### PR DESCRIPTION
This allows you to only test a subset of the tests.  The environment
variable should containing two integers separated by a space. The
first integer is the divisor, and the second is the remainder.
Tests are sequentially numbered (starting at 0), and if the
environment variable is set, the test is skipped unless the test
number divided by the divisor is equal to the remainder.

As an example TESTS_DIV_MOD="2 0" will run half the tests, and
TESTS_DIV_MOD="2 1" will run the other half, TESTS_DIV_MOD="4 0"
will run a quarter of the tests, and values of "4 1", "4 2", and
"4 3" will run the other three quarters, respectively.  This allows
for simple test splitting or parallelization (when run on different
databases).