### PR TITLE
Support :table_exists_uses_show_tables Database option to avoid errors

### DIFF
--- a/spec/schema_test.rb
+++ b/spec/schema_test.rb
@@ -129,13 +129,29 @@ describe "Database schema modifiers" do
     @ds = @db[:items]
   end
   after do
+    @db.opts[:table_exists_uses_show_tables] = false
     @db.drop_table?(:items)
     @db.drop_table?(:items2)
   end
 
   it "should create tables correctly" do
+    current_database = @db.get{current_database.function}
+    @db.table_exists?(:items).must_equal false
+    @db.table_exists?(Sequel.qualify(current_database, :items)).must_equal false
+
+    @db.opts[:table_exists_uses_show_tables] = true
+    @db.table_exists?(:items).must_equal false
+    @db.table_exists?(Sequel.qualify(current_database, :items)).must_equal false
+
     @db.create_table!(:items){Integer :number}
+    @db.opts[:table_exists_uses_show_tables] = false
     @db.table_exists?(:items).must_equal true
+    @db.table_exists?(Sequel.qualify(current_database, :items)).must_equal true
+
+    @db.opts[:table_exists_uses_show_tables] = true
+    @db.table_exists?(:items).must_equal true
+    @db.table_exists?(Sequel.qualify(current_database, :items)).must_equal true
+
     @db.schema(:items, :reload=>true).map{|x| x.first}.must_equal [:number]
     @ds.insert([10])
     @ds.columns!.must_equal [:number]


### PR DESCRIPTION
This makes Database#table_exists? use SHOW TABLES instead of trying
a SELECT query.  The SELECT query approach is Sequel's default, but
it can result in errors being logged in the database query log, which
some users may want to avoid.