### PR TITLE
Support :treat_views_as_tables Database option for treating views as tables

### DIFF
--- a/lib/sequel/adapters/shared/impala.rb
+++ b/lib/sequel/adapters/shared/impala.rb
@@ -360,9 +360,11 @@ module Sequel
         end
       end
 
-      # SHOW TABLE STATS will raise an error if given a view and not a table,
-      # so use that to differentiate tables from views.
+      # Use a separate DESCRIBE query for each table to determine if it is a
+      # table or a view.
       def is_valid_table?(t, opts=OPTS)
+        return true if self.opts[:treat_views_as_tables]
+
         t = Sequel.qualify(opts[:schema], t) if opts[:schema] && t.is_a?(Symbol)
         rows = describe(t, :formatted=>true)
         if row = rows.find{|r| r[:name].to_s.strip == 'Table Type:'}

--- a/spec/schema_test.rb
+++ b/spec/schema_test.rb
@@ -314,6 +314,7 @@ describe "Database#tables and #views" do
     @db.create_view :sequel_test_view, @db[:sequel_test_table]
   end
   after do
+    @db.opts[:treat_views_as_tables] = false
     @db.drop_view :sequel_test_view
     @db.drop_table :sequel_test_table
   end
@@ -324,6 +325,15 @@ describe "Database#tables and #views" do
     ts.each{|t| t.must_be_kind_of(Symbol)}
     ts.must_include(:sequel_test_table)
     ts.wont_include(:sequel_test_view)
+  end
+
+  it "#tables should return an array of table and view symbols if :treat_views_as_tables option is used" do
+    @db.opts[:treat_views_as_tables] = true
+    ts = @db.tables
+    ts.must_be_kind_of(Array)
+    ts.each{|t| t.must_be_kind_of(Symbol)}
+    ts.must_include(:sequel_test_table)
+    ts.must_include(:sequel_test_view)
   end
 
   describe "when using qualify on a known schema" do
@@ -350,6 +360,11 @@ describe "Database#tables and #views" do
     ts.each{|t| t.must_be_kind_of(Symbol)}
     ts.wont_include(:sequel_test_table)
     ts.must_include(:sequel_test_view)
+  end
+
+  it "#views should return an empty array if :treat_views_as_tables option is used" do
+    @db.opts[:treat_views_as_tables] = true
+    @db.views.must_equal []
   end
 
   describe "with identifier mangling" do


### PR DESCRIPTION
The main reason to do this is it can make Database#tables much faster,
since it only has to do one query instead of one query per table/view
to determine if the entry is a table or view.